### PR TITLE
DLL optimization reduce Dll footprint 30-80% - add GetDllOffset for ordinals

### DIFF
--- a/src/D2Ptrs.h
+++ b/src/D2Ptrs.h
@@ -32,20 +32,22 @@
 *                                                                           *
 *****************************************************************************/
 
-/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-//  These are the macros used by the template core to declare                                                                                                                                                         ///
-//  pointers. Do not touch unless you know what you're doing                                                                                                                                                          ///
-//                                                                                                                                                                                                                    ///
-#ifdef _MSC_VER // eliminate duplicates in msvc - enable /OPT:ICF linker option                                                                                                                                       ///
-#define D2FUNC(DLL, NAME, RETURN, CONV, ARGS, OFFSET) typedef RETURN (CONV##* DLL##_##NAME##_t) ARGS; __declspec(selectany) extern DLL##_##NAME##_t DLL##_##NAME = (DLL##_##NAME##_t)(DLLBASE_##DLL + OFFSET);        ///
-#define D2VAR(DLL, NAME, TYPE, OFFSET) typedef TYPE DLL##_##NAME##_vt; __declspec(selectany) extern DLL##_##NAME##_vt * DLL##_##NAME = (DLL##_##NAME##_vt *)(DLLBASE_##DLL + OFFSET);                                 ///
-#define D2PTR(DLL, NAME, OFFSET) __declspec(selectany) extern DWORD NAME = (DLLBASE_##DLL + OFFSET);                                                                                                                  ///
-#else // GCC placeholder test extern __attribute__((weak)) in place of static                                                                                                                                         ///
-#define D2FUNC(DLL, NAME, RETURN, CONV, ARGS, OFFSET) typedef RETURN (CONV##* DLL##_##NAME##_t) ARGS; static DLL##_##NAME##_t DLL##_##NAME = (DLL##_##NAME##_t)(DLLBASE_##DLL + OFFSET);                              ///
-#define D2VAR(DLL, NAME, TYPE, OFFSET) typedef TYPE DLL##_##NAME##_vt; static DLL##_##NAME##_vt * DLL##_##NAME = (DLL##_##NAME##_vt *)(DLLBASE_##DLL + OFFSET);                                                       ///
-#define D2PTR(DLL, NAME, OFFSET) static DWORD NAME = (DLLBASE_##DLL + OFFSET);                                                                                                                                        ///
-#endif                                                                                                                                                                                                                ///
-/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//  These are the macros used by the template core to declare                                                                                                                                                                ///
+//  pointers. Do not touch unless you know what you're doing                                                                                                                                                                 ///
+//                                                                                                                                                                                                                           ///
+#ifdef _MSC_VER // MS Compiler def's                                                                                                                                                                                         ///
+#define D2FUNC(DLL, NAME, RETURN, CONV, ARGS, OFFSET) typedef RETURN (CONV##* DLL##_##NAME##_t) ARGS; __declspec(selectany) extern DLL##_##NAME##_t DLL##_##NAME = (DLL##_##NAME##_t)GetDllOffset(DLLBASE_##DLL, OFFSET);    ///
+#define D2VAR(DLL, NAME, TYPE, OFFSET) typedef TYPE DLL##_##NAME##_vt; __declspec(selectany) extern DLL##_##NAME##_vt * DLL##_##NAME = (DLL##_##NAME##_vt *)GetDllOffset(DLLBASE_##DLL, OFFSET);                             ///
+#define D2PTR(DLL, NAME, OFFSET) __declspec(selectany) extern DWORD NAME = GetDllOffset(DLLBASE_##DLL, OFFSET);                                                                                                              ///
+#else //GCC Compiler def's                                                                                                                                                                                                   ///
+#define D2FUNC(DLL, NAME, RETURN, CONV, ARGS, OFFSET) typedef RETURN (CONV* DLL##_##NAME##_t) ARGS; DLL##_##NAME##_t DLL##_##NAME __attribute__((weak)) = (DLL##_##NAME##_t)GetDllOffset(DLLBASE_##DLL, OFFSET);             ///
+#define D2VAR(DLL, NAME, TYPE, OFFSET) typedef TYPE DLL##_##NAME##_vt; DLL##_##NAME##_vt * DLL##_##NAME __attribute__((weak)) = (DLL##_##NAME##_vt *)GetDllOffset(DLLBASE_##DLL, OFFSET);                                    ///
+#define D2PTR(DLL, NAME, OFFSET) DWORD NAME __attribute__((weak)) = GetDllOffset(DLLBASE_##DLL, OFFSET);                                                                                                                     ///
+#endif                                                                                                                                                                                                                       ///
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+extern DWORD GetDllOffset(DWORD Module, int Offset);
+
 
 /********************************************************************************
 *                                                                               *

--- a/src/D2Ptrs.h
+++ b/src/D2Ptrs.h
@@ -32,14 +32,20 @@
 *                                                                           *
 *****************************************************************************/
 
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-//  These are the macros used by the template core to declare                                                                                                                                   ///
-//  pointers. Do not touch unless you know what you're doing                                                                                                                                    ///
-//                                                                                                                                                                                              ///
-#define D2FUNC(DLL, NAME, RETURN, CONV, ARGS, OFFSET) typedef RETURN (CONV##* DLL##_##NAME##_t) ARGS; static DLL##_##NAME##_t DLL##_##NAME = (DLL##_##NAME##_t)(DLLBASE_##DLL + OFFSET);        ///
-#define D2VAR(DLL, NAME, TYPE, OFFSET) typedef TYPE DLL##_##NAME##_vt; static DLL##_##NAME##_vt * DLL##_##NAME = (DLL##_##NAME##_vt *)(DLLBASE_##DLL + OFFSET);                                 ///
-#define D2PTR(DLL, NAME, OFFSET) static DWORD NAME = (DLLBASE_##DLL + OFFSET);                                                                                                                  ///
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//  These are the macros used by the template core to declare                                                                                                                                                         ///
+//  pointers. Do not touch unless you know what you're doing                                                                                                                                                          ///
+//                                                                                                                                                                                                                    ///
+#ifdef _MSC_VER // eliminate duplicates in msvc - enable /OPT:ICF linker option                                                                                                                                       ///
+#define D2FUNC(DLL, NAME, RETURN, CONV, ARGS, OFFSET) typedef RETURN (CONV##* DLL##_##NAME##_t) ARGS; __declspec(selectany) extern DLL##_##NAME##_t DLL##_##NAME = (DLL##_##NAME##_t)(DLLBASE_##DLL + OFFSET);        ///
+#define D2VAR(DLL, NAME, TYPE, OFFSET) typedef TYPE DLL##_##NAME##_vt; __declspec(selectany) extern DLL##_##NAME##_vt * DLL##_##NAME = (DLL##_##NAME##_vt *)(DLLBASE_##DLL + OFFSET);                                 ///
+#define D2PTR(DLL, NAME, OFFSET) __declspec(selectany) extern DWORD NAME = (DLLBASE_##DLL + OFFSET);                                                                                                                  ///
+#else // GCC placeholder test extern __attribute__((weak)) in place of static                                                                                                                                         ///
+#define D2FUNC(DLL, NAME, RETURN, CONV, ARGS, OFFSET) typedef RETURN (CONV##* DLL##_##NAME##_t) ARGS; static DLL##_##NAME##_t DLL##_##NAME = (DLL##_##NAME##_t)(DLLBASE_##DLL + OFFSET);                              ///
+#define D2VAR(DLL, NAME, TYPE, OFFSET) typedef TYPE DLL##_##NAME##_vt; static DLL##_##NAME##_vt * DLL##_##NAME = (DLL##_##NAME##_vt *)(DLLBASE_##DLL + OFFSET);                                                       ///
+#define D2PTR(DLL, NAME, OFFSET) static DWORD NAME = (DLLBASE_##DLL + OFFSET);                                                                                                                                        ///
+#endif                                                                                                                                                                                                                ///
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 /********************************************************************************
 *                                                                               *

--- a/src/DLLmain.cpp
+++ b/src/DLLmain.cpp
@@ -40,7 +40,7 @@ BOOL __fastcall D2TEMPLATE_ApplyPatch(void* hGame, const DLLPatchStrc* hPatch)
         int nReturn = 0;
         int nDLL = hPatch->nDLL;
         if (nDLL < 0 || nDLL >= D2DLL_INVALID) return FALSE;
-        
+
         DWORD dwAddress = hPatch->dwAddress;
         if (!dwAddress) return FALSE;
 
@@ -48,10 +48,10 @@ BOOL __fastcall D2TEMPLATE_ApplyPatch(void* hGame, const DLLPatchStrc* hPatch)
         if (!dwBaseAddress) return FALSE;
 
         dwAddress += dwBaseAddress;
-        
+
         DWORD dwData = hPatch->dwData;
         if (hPatch->bRelative){ dwData = dwData - (dwAddress + sizeof(dwData)); }
-        
+
         void* hAddress = (void*)dwAddress;
         DWORD dwOldPage;
 
@@ -73,12 +73,12 @@ BOOL __fastcall D2TEMPLATE_ApplyPatch(void* hGame, const DLLPatchStrc* hPatch)
             nReturn = WriteProcessMemory(hGame, hAddress, &dwData, sizeof(dwData), 0);
             VirtualProtect(hAddress, sizeof(dwData), dwOldPage, 0);
         }
-        
+
         if (nReturn == 0) return FALSE;
-        
+
         hPatch++;
     }
-    
+
     return TRUE;
 }
 
@@ -87,7 +87,7 @@ BOOL __fastcall D2TEMPLATE_LoadModules()
     for (int i = 0; i < D2DLL_INVALID; i++)
     {
         DLLBaseStrc* hDllFile = &gptDllFiles[i];
-        
+
         void* hModule = GetModuleHandle(hDllFile->szName);
         if (!hModule)
         {
@@ -138,7 +138,7 @@ int __stdcall DllAttach()
     D2TEMPLATE_GetDebugPrivilege();
 
     void* hGame = GetCurrentProcess();
-    if (!hGame) 
+    if (!hGame)
     {
         D2TEMPLATE_FatalError("Failed to retrieve process");
         return 0;
@@ -167,4 +167,12 @@ int __stdcall DllMain(HINSTANCE hModule, DWORD dwReason, void* lpReserved)
     }
 
     return TRUE;
+}
+
+DWORD GetDllOffset(DWORD Module, int Offset)
+{
+	if(Offset < 0)
+		return (DWORD)GetProcAddress((HMODULE)Module,(LPCSTR)(-Offset));
+    else
+        return Module + Offset;
 }

--- a/src/DLLmain.h
+++ b/src/DLLmain.h
@@ -31,56 +31,52 @@
 #include <stdlib.h>
 
 
-#ifdef _MSC_VER // eliminate duplicates in msvc - enable /OPT:ICF linker option
-
-__declspec(selectany) extern const DWORD BNCLIENT          =  (DWORD)LoadLibraryA("Bnclient.dll");
-__declspec(selectany) extern const DWORD D2CLIENT          =  (DWORD)LoadLibraryA("D2Client.dll");
-__declspec(selectany) extern const DWORD D2CMP             =  (DWORD)LoadLibraryA("D2CMP.dll");
-__declspec(selectany) extern const DWORD D2COMMON          =  (DWORD)LoadLibraryA("D2Common.dll");
-__declspec(selectany) extern const DWORD D2DDRAW           =  (DWORD)LoadLibraryA("D2DDraw.dll");
-__declspec(selectany) extern const DWORD D2DIRECT3D        =  (DWORD)LoadLibraryA("D2Direct3D.dll");
-__declspec(selectany) extern const DWORD D2GAME            =  (DWORD)LoadLibraryA("D2Game.dll");
-__declspec(selectany) extern const DWORD D2GDI             =  (DWORD)LoadLibraryA("D2Gdi.dll");
-__declspec(selectany) extern const DWORD D2GFX             =  (DWORD)LoadLibraryA("D2Gfx.dll");
-__declspec(selectany) extern const DWORD D2GLIDE           =  (DWORD)LoadLibraryA("D2Glide.dll");
-__declspec(selectany) extern const DWORD D2LANG            =  (DWORD)LoadLibraryA("D2Lang.dll");
-__declspec(selectany) extern const DWORD D2LAUNCH          =  (DWORD)LoadLibraryA("D2Launch.dll");
-__declspec(selectany) extern const DWORD D2MCPCLIENT       =  (DWORD)LoadLibraryA("D2MCPClient.dll");
-__declspec(selectany) extern const DWORD D2MULTI           =  (DWORD)LoadLibraryA("D2Multi.dll");
-__declspec(selectany) extern const DWORD D2NET             =  (DWORD)LoadLibraryA("D2Net.dll");
-__declspec(selectany) extern const DWORD D2SOUND           =  (DWORD)LoadLibraryA("D2Sound.dll");
-__declspec(selectany) extern const DWORD D2WIN             =  (DWORD)LoadLibraryA("D2Win.dll");
-__declspec(selectany) extern const DWORD FOG               =  (DWORD)LoadLibraryA("Fog.dll");
-__declspec(selectany) extern const DWORD STORM             =  (DWORD)LoadLibraryA("Storm.dll");
-__declspec(selectany) extern const DWORD DLLBASE_IJL11     =  (DWORD)LoadLibraryA("ijl11.dll");
-__declspec(selectany) extern const DWORD DLLBASE_BINKW32   =  (DWORD)LoadLibraryA("binkw32.dll");
-__declspec(selectany) extern const DWORD DLLBASE_SMACKW32  =  (DWORD)LoadLibraryA("SmackW32.dll");
-
-#else // GCC placeholder test with extern const __attribute__((weak))  
-
-static const DWORD DLLBASE_BNCLIENT     =   (DWORD)LoadLibraryA("Bnclient.dll");
-static const DWORD DLLBASE_D2CLIENT     =   (DWORD)LoadLibraryA("D2Client.dll");
-static const DWORD DLLBASE_D2CMP        =   (DWORD)LoadLibraryA("D2CMP.dll");
-static const DWORD DLLBASE_D2COMMON     =   (DWORD)LoadLibraryA("D2Common.dll");
-static const DWORD DLLBASE_D2DDRAW      =   (DWORD)LoadLibraryA("D2DDraw.dll");
-static const DWORD DLLBASE_D2DIRECT3D   =   (DWORD)LoadLibraryA("D2Direct3D.dll");
-static const DWORD DLLBASE_D2GAME       =   (DWORD)LoadLibraryA("D2Game.dll");
-static const DWORD DLLBASE_D2GDI        =   (DWORD)LoadLibraryA("D2Gdi.dll");
-static const DWORD DLLBASE_D2GFX        =   (DWORD)LoadLibraryA("D2Gfx.dll");
-static const DWORD DLLBASE_D2GLIDE      =   (DWORD)LoadLibraryA("D2Glide.dll");
-static const DWORD DLLBASE_D2LANG       =   (DWORD)LoadLibraryA("D2Lang.dll");
-static const DWORD DLLBASE_D2LAUNCH     =   (DWORD)LoadLibraryA("D2Launch.dll");
-static const DWORD DLLBASE_D2MCPCLIENT  =   (DWORD)LoadLibraryA("D2MCPClient.dll");
-static const DWORD DLLBASE_D2MULTI      =   (DWORD)LoadLibraryA("D2Multi.dll");
-static const DWORD DLLBASE_D2NET        =   (DWORD)LoadLibraryA("D2Net.dll");
-static const DWORD DLLBASE_D2SOUND      =   (DWORD)LoadLibraryA("D2Sound.dll");
-static const DWORD DLLBASE_D2WIN        =   (DWORD)LoadLibraryA("D2Win.dll");
-static const DWORD DLLBASE_FOG          =   (DWORD)LoadLibraryA("Fog.dll");
-static const DWORD DLLBASE_STORM        =   (DWORD)LoadLibraryA("Storm.dll");
-static const DWORD DLLBASE_IJL11        =   (DWORD)LoadLibraryA("ijl11.dll");
-static const DWORD DLLBASE_BINKW32      =   (DWORD)LoadLibraryA("binkw32.dll");
-static const DWORD DLLBASE_SMACKW32     =   (DWORD)LoadLibraryA("SmackW32.dll");
-
+#ifdef _MSC_VER // MS Compiler def's
+__declspec(selectany) extern const DWORD DLLBASE_BNCLIENT     =   (DWORD)LoadLibraryA("Bnclient.dll");
+__declspec(selectany) extern const DWORD DLLBASE_D2CLIENT     =   (DWORD)LoadLibraryA("D2Client.dll");
+__declspec(selectany) extern const DWORD DLLBASE_D2CMP        =   (DWORD)LoadLibraryA("D2CMP.dll");
+__declspec(selectany) extern const DWORD DLLBASE_D2COMMON     =   (DWORD)LoadLibraryA("D2Common.dll");
+__declspec(selectany) extern const DWORD DLLBASE_D2DDRAW      =   (DWORD)LoadLibraryA("D2DDraw.dll");
+__declspec(selectany) extern const DWORD DLLBASE_D2DIRECT3D   =   (DWORD)LoadLibraryA("D2Direct3D.dll");
+__declspec(selectany) extern const DWORD DLLBASE_D2GAME       =   (DWORD)LoadLibraryA("D2Game.dll");
+__declspec(selectany) extern const DWORD DLLBASE_D2GDI        =   (DWORD)LoadLibraryA("D2Gdi.dll");
+__declspec(selectany) extern const DWORD DLLBASE_D2GFX        =   (DWORD)LoadLibraryA("D2Gfx.dll");
+__declspec(selectany) extern const DWORD DLLBASE_D2GLIDE      =   (DWORD)LoadLibraryA("D2Glide.dll");
+__declspec(selectany) extern const DWORD DLLBASE_D2LANG       =   (DWORD)LoadLibraryA("D2Lang.dll");
+__declspec(selectany) extern const DWORD DLLBASE_D2LAUNCH     =   (DWORD)LoadLibraryA("D2Launch.dll");
+__declspec(selectany) extern const DWORD DLLBASE_D2MCPCLIENT  =   (DWORD)LoadLibraryA("D2MCPClient.dll");
+__declspec(selectany) extern const DWORD DLLBASE_D2MULTI      =   (DWORD)LoadLibraryA("D2Multi.dll");
+__declspec(selectany) extern const DWORD DLLBASE_D2NET        =   (DWORD)LoadLibraryA("D2Net.dll");
+__declspec(selectany) extern const DWORD DLLBASE_D2SOUND      =   (DWORD)LoadLibraryA("D2Sound.dll");
+__declspec(selectany) extern const DWORD DLLBASE_D2WIN        =   (DWORD)LoadLibraryA("D2Win.dll");
+__declspec(selectany) extern const DWORD DLLBASE_FOG          =   (DWORD)LoadLibraryA("Fog.dll");
+__declspec(selectany) extern const DWORD DLLBASE_STORM        =   (DWORD)LoadLibraryA("Storm.dll");
+__declspec(selectany) extern const DWORD DLLBASE_IJL11        =   (DWORD)LoadLibraryA("ijl11.dll");
+__declspec(selectany) extern const DWORD DLLBASE_BINKW32      =   (DWORD)LoadLibraryA("binkw32.dll");
+__declspec(selectany) extern const DWORD DLLBASE_SMACKW32     =   (DWORD)LoadLibraryA("SmackW32.dll");
+#else //GCC Compiler def's
+extern const DWORD DLLBASE_BNCLIENT __attribute__((weak))     =   (DWORD)LoadLibraryA("Bnclient.dll");
+extern const DWORD DLLBASE_D2CLIENT __attribute__((weak))     =   (DWORD)LoadLibraryA("D2Client.dll");
+extern const DWORD DLLBASE_D2CMP __attribute__((weak))        =   (DWORD)LoadLibraryA("D2CMP.dll");
+extern const DWORD DLLBASE_D2COMMON __attribute__((weak))     =   (DWORD)LoadLibraryA("D2Common.dll");
+extern const DWORD DLLBASE_D2DDRAW __attribute__((weak))      =   (DWORD)LoadLibraryA("D2DDraw.dll");
+extern const DWORD DLLBASE_D2DIRECT3D __attribute__((weak))   =   (DWORD)LoadLibraryA("D2Direct3D.dll");
+extern const DWORD DLLBASE_D2GAME __attribute__((weak))       =   (DWORD)LoadLibraryA("D2Game.dll");
+extern const DWORD DLLBASE_D2GDI __attribute__((weak))        =   (DWORD)LoadLibraryA("D2Gdi.dll");
+extern const DWORD DLLBASE_D2GFX __attribute__((weak))        =   (DWORD)LoadLibraryA("D2Gfx.dll");
+extern const DWORD DLLBASE_D2GLIDE __attribute__((weak))      =   (DWORD)LoadLibraryA("D2Glide.dll");
+extern const DWORD DLLBASE_D2LANG  __attribute__((weak))      =   (DWORD)LoadLibraryA("D2Lang.dll");
+extern const DWORD DLLBASE_D2LAUNCH  __attribute__((weak))    =   (DWORD)LoadLibraryA("D2Launch.dll");
+extern const DWORD DLLBASE_D2MCPCLIENT __attribute__((weak))  =   (DWORD)LoadLibraryA("D2MCPClient.dll");
+extern const DWORD DLLBASE_D2MULTI __attribute__((weak))      =   (DWORD)LoadLibraryA("D2Multi.dll");
+extern const DWORD DLLBASE_D2NET __attribute__((weak))        =   (DWORD)LoadLibraryA("D2Net.dll");
+extern const DWORD DLLBASE_D2SOUND __attribute__((weak))      =   (DWORD)LoadLibraryA("D2Sound.dll");
+extern const DWORD DLLBASE_D2WIN __attribute__((weak))        =   (DWORD)LoadLibraryA("D2Win.dll");
+extern const DWORD DLLBASE_FOG __attribute__((weak))          =   (DWORD)LoadLibraryA("Fog.dll");
+extern const DWORD DLLBASE_STORM __attribute__((weak))        =   (DWORD)LoadLibraryA("Storm.dll");
+extern const DWORD DLLBASE_IJL11 __attribute__((weak))        =   (DWORD)LoadLibraryA("ijl11.dll");
+extern const DWORD DLLBASE_BINKW32 __attribute__((weak))      =   (DWORD)LoadLibraryA("binkw32.dll");
+extern const DWORD DLLBASE_SMACKW32 __attribute__((weak))     =   (DWORD)LoadLibraryA("SmackW32.dll");
 #endif
 
 #include "D2Constants.h"

--- a/src/DLLmain.h
+++ b/src/DLLmain.h
@@ -30,28 +30,58 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-static const DWORD DLLBASE_BNCLIENT		=	(DWORD)LoadLibraryA("Bnclient.dll");
-static const DWORD DLLBASE_D2CLIENT		=	(DWORD)LoadLibraryA("D2Client.dll");
-static const DWORD DLLBASE_D2CMP		=	(DWORD)LoadLibraryA("D2CMP.dll");
-static const DWORD DLLBASE_D2COMMON		=	(DWORD)LoadLibraryA("D2Common.dll");
-static const DWORD DLLBASE_D2DDRAW		=	(DWORD)LoadLibraryA("D2DDraw.dll");
-static const DWORD DLLBASE_D2DIRECT3D	=	(DWORD)LoadLibraryA("D2Direct3D.dll");
-static const DWORD DLLBASE_D2GAME		=	(DWORD)LoadLibraryA("D2Game.dll");
-static const DWORD DLLBASE_D2GDI		=	(DWORD)LoadLibraryA("D2Gdi.dll");
-static const DWORD DLLBASE_D2GFX		=	(DWORD)LoadLibraryA("D2Gfx.dll");
-static const DWORD DLLBASE_D2GLIDE		=	(DWORD)LoadLibraryA("D2Glide.dll");
-static const DWORD DLLBASE_D2LANG		=	(DWORD)LoadLibraryA("D2Lang.dll");
-static const DWORD DLLBASE_D2LAUNCH		=	(DWORD)LoadLibraryA("D2Launch.dll");
-static const DWORD DLLBASE_D2MCPCLIENT	=	(DWORD)LoadLibraryA("D2MCPClient.dll");
-static const DWORD DLLBASE_D2MULTI		=	(DWORD)LoadLibraryA("D2Multi.dll");
-static const DWORD DLLBASE_D2NET		=	(DWORD)LoadLibraryA("D2Net.dll");
-static const DWORD DLLBASE_D2SOUND		=	(DWORD)LoadLibraryA("D2Sound.dll");
-static const DWORD DLLBASE_D2WIN		=	(DWORD)LoadLibraryA("D2Win.dll");
-static const DWORD DLLBASE_FOG			=	(DWORD)LoadLibraryA("Fog.dll");
-static const DWORD DLLBASE_STORM		=	(DWORD)LoadLibraryA("Storm.dll");
-static const DWORD DLLBASE_IJL11		=	(DWORD)LoadLibraryA("ijl11.dll");
-static const DWORD DLLBASE_BINKW32		=	(DWORD)LoadLibraryA("binkw32.dll");
-static const DWORD DLLBASE_SMACKW32		=	(DWORD)LoadLibraryA("SmackW32.dll");
+
+#ifdef _MSC_VER // eliminate duplicates in msvc - enable /OPT:ICF linker option
+
+__declspec(selectany) extern const DWORD BNCLIENT          =  (DWORD)LoadLibraryA("Bnclient.dll");
+__declspec(selectany) extern const DWORD D2CLIENT          =  (DWORD)LoadLibraryA("D2Client.dll");
+__declspec(selectany) extern const DWORD D2CMP             =  (DWORD)LoadLibraryA("D2CMP.dll");
+__declspec(selectany) extern const DWORD D2COMMON          =  (DWORD)LoadLibraryA("D2Common.dll");
+__declspec(selectany) extern const DWORD D2DDRAW           =  (DWORD)LoadLibraryA("D2DDraw.dll");
+__declspec(selectany) extern const DWORD D2DIRECT3D        =  (DWORD)LoadLibraryA("D2Direct3D.dll");
+__declspec(selectany) extern const DWORD D2GAME            =  (DWORD)LoadLibraryA("D2Game.dll");
+__declspec(selectany) extern const DWORD D2GDI             =  (DWORD)LoadLibraryA("D2Gdi.dll");
+__declspec(selectany) extern const DWORD D2GFX             =  (DWORD)LoadLibraryA("D2Gfx.dll");
+__declspec(selectany) extern const DWORD D2GLIDE           =  (DWORD)LoadLibraryA("D2Glide.dll");
+__declspec(selectany) extern const DWORD D2LANG            =  (DWORD)LoadLibraryA("D2Lang.dll");
+__declspec(selectany) extern const DWORD D2LAUNCH          =  (DWORD)LoadLibraryA("D2Launch.dll");
+__declspec(selectany) extern const DWORD D2MCPCLIENT       =  (DWORD)LoadLibraryA("D2MCPClient.dll");
+__declspec(selectany) extern const DWORD D2MULTI           =  (DWORD)LoadLibraryA("D2Multi.dll");
+__declspec(selectany) extern const DWORD D2NET             =  (DWORD)LoadLibraryA("D2Net.dll");
+__declspec(selectany) extern const DWORD D2SOUND           =  (DWORD)LoadLibraryA("D2Sound.dll");
+__declspec(selectany) extern const DWORD D2WIN             =  (DWORD)LoadLibraryA("D2Win.dll");
+__declspec(selectany) extern const DWORD FOG               =  (DWORD)LoadLibraryA("Fog.dll");
+__declspec(selectany) extern const DWORD STORM             =  (DWORD)LoadLibraryA("Storm.dll");
+__declspec(selectany) extern const DWORD DLLBASE_IJL11     =  (DWORD)LoadLibraryA("ijl11.dll");
+__declspec(selectany) extern const DWORD DLLBASE_BINKW32   =  (DWORD)LoadLibraryA("binkw32.dll");
+__declspec(selectany) extern const DWORD DLLBASE_SMACKW32  =  (DWORD)LoadLibraryA("SmackW32.dll");
+
+#else // GCC placeholder test with extern const __attribute__((weak))  
+
+static const DWORD DLLBASE_BNCLIENT     =   (DWORD)LoadLibraryA("Bnclient.dll");
+static const DWORD DLLBASE_D2CLIENT     =   (DWORD)LoadLibraryA("D2Client.dll");
+static const DWORD DLLBASE_D2CMP        =   (DWORD)LoadLibraryA("D2CMP.dll");
+static const DWORD DLLBASE_D2COMMON     =   (DWORD)LoadLibraryA("D2Common.dll");
+static const DWORD DLLBASE_D2DDRAW      =   (DWORD)LoadLibraryA("D2DDraw.dll");
+static const DWORD DLLBASE_D2DIRECT3D   =   (DWORD)LoadLibraryA("D2Direct3D.dll");
+static const DWORD DLLBASE_D2GAME       =   (DWORD)LoadLibraryA("D2Game.dll");
+static const DWORD DLLBASE_D2GDI        =   (DWORD)LoadLibraryA("D2Gdi.dll");
+static const DWORD DLLBASE_D2GFX        =   (DWORD)LoadLibraryA("D2Gfx.dll");
+static const DWORD DLLBASE_D2GLIDE      =   (DWORD)LoadLibraryA("D2Glide.dll");
+static const DWORD DLLBASE_D2LANG       =   (DWORD)LoadLibraryA("D2Lang.dll");
+static const DWORD DLLBASE_D2LAUNCH     =   (DWORD)LoadLibraryA("D2Launch.dll");
+static const DWORD DLLBASE_D2MCPCLIENT  =   (DWORD)LoadLibraryA("D2MCPClient.dll");
+static const DWORD DLLBASE_D2MULTI      =   (DWORD)LoadLibraryA("D2Multi.dll");
+static const DWORD DLLBASE_D2NET        =   (DWORD)LoadLibraryA("D2Net.dll");
+static const DWORD DLLBASE_D2SOUND      =   (DWORD)LoadLibraryA("D2Sound.dll");
+static const DWORD DLLBASE_D2WIN        =   (DWORD)LoadLibraryA("D2Win.dll");
+static const DWORD DLLBASE_FOG          =   (DWORD)LoadLibraryA("Fog.dll");
+static const DWORD DLLBASE_STORM        =   (DWORD)LoadLibraryA("Storm.dll");
+static const DWORD DLLBASE_IJL11        =   (DWORD)LoadLibraryA("ijl11.dll");
+static const DWORD DLLBASE_BINKW32      =   (DWORD)LoadLibraryA("binkw32.dll");
+static const DWORD DLLBASE_SMACKW32     =   (DWORD)LoadLibraryA("SmackW32.dll");
+
+#endif
 
 #include "D2Constants.h"
 #include "D2Structs.h"


### PR DESCRIPTION
Eliminates duplicate pointers for #include "D2Ptrs.h" to all translational units.
Eliminates duplicates module def's for #include "DLLmain.h" to all translational units.
Both need /OPT:ICF linker option (COMDAT FOLDING) to get reduction in size from. - Enabled by default
Updates def's for GCC
Add GetDllOffset function for ordinals