### PR TITLE
Reduce Dll footprint 30-80% - Add GetDllOffset for Ordinals

### DIFF
--- a/src/D2Ptrs.h
+++ b/src/D2Ptrs.h
@@ -32,14 +32,22 @@
 *                                                                           *
 *****************************************************************************/
 
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-//  These are the macros used by the template core to declare                                                                                                                                   ///
-//  pointers. Do not touch unless you know what you're doing                                                                                                                                    ///
-//                                                                                                                                                                                              ///
-#define D2FUNC(DLL, NAME, RETURN, CONV, ARGS, OFFSET) typedef RETURN (CONV##* DLL##_##NAME##_t) ARGS; static DLL##_##NAME##_t DLL##_##NAME = (DLL##_##NAME##_t)(DLLBASE_##DLL + OFFSET);        ///
-#define D2VAR(DLL, NAME, TYPE, OFFSET) typedef TYPE DLL##_##NAME##_vt; static DLL##_##NAME##_vt * DLL##_##NAME = (DLL##_##NAME##_vt *)(DLLBASE_##DLL + OFFSET);                                 ///
-#define D2PTR(DLL, NAME, OFFSET) static DWORD NAME = (DLLBASE_##DLL + OFFSET);                                                                                                                  ///
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//  These are the macros used by the template core to declare                                                                                                                                                                   ///
+//  pointers. Do not touch unless you know what you're doing                                                                                                                                                                    ///
+//                                                                                                                                                                                                                              ///
+//                                                                                                                                                                                                                              ///
+#ifdef _MSC_VER // MS Compiler                                                                                                                                                                                                  ///
+#define D2FUNC(DLL, NAME, RETURN, CONV, ARGS, OFFSET) typedef RETURN (CONV* DLL##_##NAME##_t) ARGS; __declspec(selectany) extern DLL##_##NAME##_t DLL##_##NAME = (DLL##_##NAME##_t)GetDllOffset(#DLL, DLLBASE_##DLL, OFFSET);   ///
+#define D2VAR(DLL, NAME, TYPE, OFFSET) typedef TYPE DLL##_##NAME##_vt; __declspec(selectany) extern DLL##_##NAME##_vt * DLL##_##NAME = (DLL##_##NAME##_vt *)GetDllOffset(#DLL, DLLBASE_##DLL, OFFSET);                          ///
+#define D2PTR(DLL, NAME, OFFSET) __declspec(selectany) extern DWORD NAME = GetDllOffset(#DLL, DLLBASE_##DLL, OFFSET);                                                                                                           ///
+#else // GCC Compiler                                                                                                                                                                                                           ///
+#define D2FUNC(DLL, NAME, RETURN, CONV, ARGS, OFFSET) typedef RETURN (CONV* DLL##_##NAME##_t) ARGS; DLL##_##NAME##_t DLL##_##NAME __attribute__((weak)) = (DLL##_##NAME##_t)GetDllOffset(#DLL, DLLBASE_##DLL, OFFSET);          ///
+#define D2VAR(DLL, NAME, TYPE, OFFSET) typedef TYPE DLL##_##NAME##_vt; DLL##_##NAME##_vt * DLL##_##NAME __attribute__((weak)) = (DLL##_##NAME##_vt *)GetDllOffset(#DLL, DLLBASE_##DLL, OFFSET);                                 ///
+#define D2PTR(DLL, NAME, OFFSET) DWORD NAME __attribute__((weak)) = GetDllOffset(#DLL, DLLBASE_##DLL, OFFSET);                                                                                                                  ///
+#endif                                                                                                                                                                                                                          ///
+extern DWORD __fastcall GetDllOffset(char* ModuleName, DWORD BaseAddress, int Offset);                                                                                                                                          ///
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 /********************************************************************************
 *                                                                               *

--- a/src/DLLmain.cpp
+++ b/src/DLLmain.cpp
@@ -168,3 +168,22 @@ int __stdcall DllMain(HINSTANCE hModule, DWORD dwReason, void* lpReserved)
 
     return TRUE;
 }
+
+DWORD __fastcall GetDllOffset(char* ModuleName, DWORD BaseAddress, int Offset)
+{
+	if(!BaseAddress)
+		BaseAddress = (DWORD)LoadLibraryA(GetModuleExt(ModuleName));
+
+	if(Offset < 0)
+		return (DWORD)GetProcAddress((HMODULE)BaseAddress,(LPCSTR)(-Offset));
+
+	return BaseAddress + Offset;
+}
+
+char* __fastcall GetModuleExt(char* ModuleName)
+{
+	char DLLExt[] = ".dll";
+	char DLLName[32] = {0};
+	strcpy(DLLName,ModuleName);
+	return strcat(DLLName,DLLExt);
+}

--- a/src/DLLmain.h
+++ b/src/DLLmain.h
@@ -30,28 +30,28 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-static const DWORD DLLBASE_BNCLIENT		=	(DWORD)LoadLibraryA("Bnclient.dll");
-static const DWORD DLLBASE_D2CLIENT		=	(DWORD)LoadLibraryA("D2Client.dll");
-static const DWORD DLLBASE_D2CMP		=	(DWORD)LoadLibraryA("D2CMP.dll");
-static const DWORD DLLBASE_D2COMMON		=	(DWORD)LoadLibraryA("D2Common.dll");
-static const DWORD DLLBASE_D2DDRAW		=	(DWORD)LoadLibraryA("D2DDraw.dll");
-static const DWORD DLLBASE_D2DIRECT3D	=	(DWORD)LoadLibraryA("D2Direct3D.dll");
-static const DWORD DLLBASE_D2GAME		=	(DWORD)LoadLibraryA("D2Game.dll");
-static const DWORD DLLBASE_D2GDI		=	(DWORD)LoadLibraryA("D2Gdi.dll");
-static const DWORD DLLBASE_D2GFX		=	(DWORD)LoadLibraryA("D2Gfx.dll");
-static const DWORD DLLBASE_D2GLIDE		=	(DWORD)LoadLibraryA("D2Glide.dll");
-static const DWORD DLLBASE_D2LANG		=	(DWORD)LoadLibraryA("D2Lang.dll");
-static const DWORD DLLBASE_D2LAUNCH		=	(DWORD)LoadLibraryA("D2Launch.dll");
-static const DWORD DLLBASE_D2MCPCLIENT	=	(DWORD)LoadLibraryA("D2MCPClient.dll");
-static const DWORD DLLBASE_D2MULTI		=	(DWORD)LoadLibraryA("D2Multi.dll");
-static const DWORD DLLBASE_D2NET		=	(DWORD)LoadLibraryA("D2Net.dll");
-static const DWORD DLLBASE_D2SOUND		=	(DWORD)LoadLibraryA("D2Sound.dll");
-static const DWORD DLLBASE_D2WIN		=	(DWORD)LoadLibraryA("D2Win.dll");
-static const DWORD DLLBASE_FOG			=	(DWORD)LoadLibraryA("Fog.dll");
-static const DWORD DLLBASE_STORM		=	(DWORD)LoadLibraryA("Storm.dll");
-static const DWORD DLLBASE_IJL11		=	(DWORD)LoadLibraryA("ijl11.dll");
-static const DWORD DLLBASE_BINKW32		=	(DWORD)LoadLibraryA("binkw32.dll");
-static const DWORD DLLBASE_SMACKW32		=	(DWORD)LoadLibraryA("SmackW32.dll");
+static const DWORD DLLBASE_BNCLIENT     =   (DWORD)LoadLibraryA("Bnclient.dll");
+static const DWORD DLLBASE_D2CLIENT     =   (DWORD)LoadLibraryA("D2Client.dll");
+static const DWORD DLLBASE_D2CMP        =   (DWORD)LoadLibraryA("D2CMP.dll");
+static const DWORD DLLBASE_D2COMMON     =   (DWORD)LoadLibraryA("D2Common.dll");
+static const DWORD DLLBASE_D2DDRAW      =   (DWORD)LoadLibraryA("D2DDraw.dll");
+static const DWORD DLLBASE_D2DIRECT3D   =   (DWORD)LoadLibraryA("D2Direct3D.dll");
+static const DWORD DLLBASE_D2GAME       =   (DWORD)LoadLibraryA("D2Game.dll");
+static const DWORD DLLBASE_D2GDI        =   (DWORD)LoadLibraryA("D2Gdi.dll");
+static const DWORD DLLBASE_D2GFX        =   (DWORD)LoadLibraryA("D2Gfx.dll");
+static const DWORD DLLBASE_D2GLIDE      =   (DWORD)LoadLibraryA("D2Glide.dll");
+static const DWORD DLLBASE_D2LANG       =   (DWORD)LoadLibraryA("D2Lang.dll");
+static const DWORD DLLBASE_D2LAUNCH     =   (DWORD)LoadLibraryA("D2Launch.dll");
+static const DWORD DLLBASE_D2MCPCLIENT  =   (DWORD)LoadLibraryA("D2MCPClient.dll");
+static const DWORD DLLBASE_D2MULTI      =   (DWORD)LoadLibraryA("D2Multi.dll");
+static const DWORD DLLBASE_D2NET        =   (DWORD)LoadLibraryA("D2Net.dll");
+static const DWORD DLLBASE_D2SOUND      =   (DWORD)LoadLibraryA("D2Sound.dll");
+static const DWORD DLLBASE_D2WIN        =   (DWORD)LoadLibraryA("D2Win.dll");
+static const DWORD DLLBASE_FOG          =   (DWORD)LoadLibraryA("Fog.dll");
+static const DWORD DLLBASE_STORM        =   (DWORD)LoadLibraryA("Storm.dll");
+static const DWORD DLLBASE_IJL11        =   (DWORD)LoadLibraryA("ijl11.dll");
+static const DWORD DLLBASE_BINKW32      =   (DWORD)LoadLibraryA("binkw32.dll");
+static const DWORD DLLBASE_SMACKW32     =   (DWORD)LoadLibraryA("SmackW32.dll");
 
 #include "D2Constants.h"
 #include "D2Structs.h"
@@ -129,3 +129,5 @@ static DLLBaseStrc gptDllFiles [] =
 };
 
 void __fastcall D2TEMPLATE_FatalError(char* szMessage);
+DWORD __fastcall GetDllOffset(char* ModuleName, DWORD BaseAddress, int Offset);
+char* __fastcall GetModuleExt(char* ModuleName);


### PR DESCRIPTION
Reduce Dll footprint 30-80% - Add GetDllOffset for Ordinals

Eliminates duplicate pointers for #include "D2Ptrs.h" to all translational units.
needs /OPT:ICF linker option (COMDAT FOLDING) to get reduction in size from.
Update def's for GCC
Add GetDllOffset for Ordinals

Update GetDllOffset to fix obscure issue with patching D2Multi.dll