### PR TITLE
Expose ApplyPatch and create PatchBytes

### DIFF
--- a/src/DLLmain.cpp
+++ b/src/DLLmain.cpp
@@ -1,6 +1,7 @@
 #define _D2VARS_H
 
 #include "DLLmain.h"
+#include <windows.h>
 #include "D2Patch.h"
 
 /****************************************************************************
@@ -57,6 +58,8 @@ BOOL __fastcall D2TEMPLATE_ApplyPatch(void* hGame, const DLLPatchStrc* hPatch)
 
         if (hPatch->nPatchSize > 0)
         {
+            if (hPatch->nPatchSize > 1024) return FALSE;
+
             BYTE Buffer[1024];
 
             for (size_t i = 0; i < hPatch->nPatchSize; i++)
@@ -79,6 +82,38 @@ BOOL __fastcall D2TEMPLATE_ApplyPatch(void* hGame, const DLLPatchStrc* hPatch)
         hPatch++;
     }
     
+    return TRUE;
+}
+
+BOOL __fastcall D2TEMPLATE_PatchBytes(void* hGame, const DLLBytesPatchStrc* hPatch)
+{
+    while (hPatch->nDLL != D2DLL_INVALID)
+    {
+        int nDLL = hPatch->nDLL;
+        if (nDLL < 0 || nDLL >= D2DLL_INVALID) return FALSE;
+
+        DWORD dwAddress = hPatch->dwAddress;
+        if (!dwAddress) return FALSE;
+
+        DWORD dwBaseAddress = gptDllFiles[nDLL].dwAddress;
+        if (!dwBaseAddress) return FALSE;
+
+        dwAddress += dwBaseAddress;
+
+        if (!hPatch->pData || hPatch->nSize == 0) return FALSE;
+
+        void* hAddress = (void*)dwAddress;
+        DWORD dwOldPage;
+
+        VirtualProtect(hAddress, hPatch->nSize, PAGE_EXECUTE_READWRITE, &dwOldPage);
+        int nReturn = WriteProcessMemory(hGame, hAddress, hPatch->pData, hPatch->nSize, 0);
+        VirtualProtect(hAddress, hPatch->nSize, dwOldPage, 0);
+
+        if (nReturn == 0) return FALSE;
+
+        hPatch++;
+    }
+
     return TRUE;
 }
 
@@ -183,7 +218,7 @@ DWORD __fastcall GetDllOffset(char* ModuleName, DWORD BaseAddress, int Offset)
 char* __fastcall GetModuleExt(char* ModuleName)
 {
 	char DLLExt[] = ".dll";
-	char DLLName[32] = {0};
+	static char DLLName[32] = {0};
 	strcpy(DLLName,ModuleName);
 	return strcat(DLLName,DLLExt);
 }

--- a/src/DLLmain.h
+++ b/src/DLLmain.h
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef _DLLMAIN_H
+#define _DLLMAIN_H
+
 /****************************************************************************
 *                                                                           *
 *   DLLmain.h                                                               *
@@ -23,7 +28,10 @@
 *****************************************************************************/
 
 #define WIN32_LEAN_AND_MEAN
+#ifndef _CRT_SECURE_NO_DEPRECATE
 #define _CRT_SECURE_NO_DEPRECATE
+#endif
+#undef _WIN32_WINNT
 #define _WIN32_WINNT 0x600
 
 #include <windows.h>
@@ -73,6 +81,17 @@ struct DLLPatchStrc
     DWORD dwData;
     BOOL bRelative;
     size_t nPatchSize;
+};
+
+/* Companion struct — mirrors DLLPatchStrc but carries a raw byte array
+ * instead of a single DWORD value.
+ * Terminate patch tables with { D2DLL_INVALID, 0, nullptr, 0 }. */
+struct DLLBytesPatchStrc
+{
+    int         nDLL;       /* target DLL index, D2DLL_INVALID = end sentinel */
+    DWORD       dwAddress;  /* offset within DLL                               */
+    const BYTE *pData;      /* pointer to byte array to write                  */
+    size_t      nSize;      /* number of bytes to write                        */
 };
 
 enum D2TEMPLATE_DLL_FILES
@@ -129,5 +148,9 @@ static DLLBaseStrc gptDllFiles [] =
 };
 
 void __fastcall D2TEMPLATE_FatalError(char* szMessage);
+BOOL __fastcall D2TEMPLATE_ApplyPatch(void* hGame, const DLLPatchStrc* hPatch);
+BOOL __fastcall D2TEMPLATE_PatchBytes(void* hGame, const DLLBytesPatchStrc* hPatch);
 DWORD __fastcall GetDllOffset(char* ModuleName, DWORD BaseAddress, int Offset);
 char* __fastcall GetModuleExt(char* ModuleName);
+
+#endif // _DLLMAIN_H


### PR DESCRIPTION
* ApplyPatch needs to be exposed when creating a mod that has multiple patches and those patches are called on conditions (e.g. .ini file).
* Created a PatchBytes function that allows for patches of different sizes.
* Made 2 small security fixes based on Google's Jules feedback

DISCLAIMER: This code was generated by Claude and Gemini when working on a project.